### PR TITLE
tag a sentence with parts of speech in english using stanford tag set

### DIFF
--- a/PartsOfSpeechTags/Stanford_POS_tag output.txt
+++ b/PartsOfSpeechTags/Stanford_POS_tag output.txt
@@ -1,0 +1,2 @@
+The_DT grand_JJ jury_NN commented_VBD on_IN a_DT number_NN of_IN other_JJ topics_NNS ._.
+There_EX are_VBP 70_CD children_NNS there_RB Although_IN preliminary_JJ findings_NNS were_VBD reported_VBN more_RBR than_IN a_DT year_NN ago_RB ,_, the_DT latest_JJS results_NNS appear_VBP in_IN today_NN 's_POS New_NNP England_NNP Journal_NNP of_IN Medicine_NNP ._.

--- a/PartsOfSpeechTags/Stanford_POS_tag_input.txt
+++ b/PartsOfSpeechTags/Stanford_POS_tag_input.txt
@@ -1,0 +1,3 @@
+The grand jury commented on a number of other topics. 
+There are 70 children there
+Although preliminary findings were reported more than a year ago, the latest results appear in today's New England Journal of Medicine. 


### PR DESCRIPTION
Takes an English sentence as input and tags it with parts of speech with '_' as delimiter.
